### PR TITLE
Block Merkle Tree definition update

### DIFF
--- a/HIP/hip-1056.md
+++ b/HIP/hip-1056.md
@@ -212,7 +212,7 @@ For each block, the `block merkle tree` is specified at a depth of two by the fo
 4. The fourth and right most subtree is the root hash of the state at the beginning of the block. 
 
 There are no constraints on the structure of the first and fourth subtrees corresponding to the previous block and the 
-state merkle trees.  The input and output subtrees, however, are balanced binary trees of the same depth to 
+state merkle trees.  The input and output subtrees, however, are full balanced binary trees of the same depth to 
 facilitate the following mathematical properties of the merkle paths in these subtrees: 
 1. Let the path from the root of the block merkle tree to a leaf in the input or output subtree be described by an 
    integer in binary form where a 0 indicates a left turn and a 1 indicates a right turn. 

--- a/HIP/hip-1056.md
+++ b/HIP/hip-1056.md
@@ -231,9 +231,10 @@ facilitate the following mathematical properties of the merkle paths in these su
    [0,1,0,0,0,0, ... 0,0] and [0,1,0,0,0,0, ... 0,1].  The merkle path to first and second transaction output block items are
    [1,0,0,0,0,0, ... 0,0] and [1,0,0,0,0,0, ... 0,1].  
 
-When whole subtrees are filtered, the block items in the subtree are replaced with a single filtered item indicating 
-the hash of the subtree and the binary merkle path to the subtree from the block merkle root. When individual leaves 
-are filtered, they are replaced with a filtered leaf item that indicates which of the four subtrees the leaf was in. 
+When whole subtrees are filtered, the block items in the subtree are replaced with a single filtered-subtree item 
+indicating the hash of the subtree and the binary merkle path to the subtree from the block merkle root. When 
+individual leaves are filtered, they are replaced with a filtered leaf item that indicates which of the four 
+subtrees the leaf was in. 
 
 > State Merkle Hash: A block contains the state hash that represents the state at the beginning of the block. 
 The hash of the state at the end of the block is found in the next block. This is because it takes time to gather state

--- a/HIP/hip-1056.md
+++ b/HIP/hip-1056.md
@@ -227,8 +227,8 @@ facilitate the following mathematical properties of the merkle paths in these su
    four subtrees.  
 6. Let [b1,b2,b3, ... ,bH] be the binary representation of the index of the block item in the subtree.  If the 
    prefix to that subtree is [a1,a2,a3] then the path to that block item in the block merkle tree is
-   [a1,a2,a3,b1,b2,b3, ... ,bH]. For example, the merkle path to the first and second consensus block items are [0,1,0,
-   0,0,0, ... 0,0] and [0,1,0,0,0,0, ... 0,1].  The merkle path to first and second transaction output block items are
+   [a1,a2,a3,b1,b2,b3, ... ,bH]. For example, the merkle path to the first and second consensus block items are      
+   [0,1,0,0,0,0, ... 0,0] and [0,1,0,0,0,0, ... 0,1].  The merkle path to first and second transaction output block items are
    [1,0,0,0,0,0, ... 0,0] and [1,0,0,0,0,0, ... 0,1].  
 
 When whole subtrees are filtered, the block items in the subtree are replaced with a single filtered item indicating 

--- a/HIP/hip-1056.md
+++ b/HIP/hip-1056.md
@@ -187,17 +187,17 @@ over the stream.
 
 The block stream items are split into two types: inputs and outputs. The input items are those known after consensus but
 before transaction execution and are the input to transaction execution. Output items are those produced during
-transaction execution. These are hashed separately into two different *block stream* merkle sub-trees. This is done so
-we can separate out a subset of historical blocks with just their input items, or just output items. That subset block
-stream could then be used for transaction replay or transaction execution verification, for example.
+transaction execution. Input items are further split between consensus items, such as event and round headers, and 
+transactions.  Output items are further split between transaction results and state changes, and items containing 
+smart contract execution traces. Each of the subtrees is hashed separately creating different *block stream* merkle 
+subtrees. Filtering can happen at the leaf level, replacing the data with its hash, or if all leaves in a 
+subtree are filtered, the whole subtree can be replaced with its hash.  The hash is preserved so that the merkle 
+tree for the block can still be validated. Separating the merkle tree into multiple distinct subtrees allows for 
+efficient filtering of the same type of data. Use cases which would benefit from subtree filtering include 
+transaction replay by filtering the output subtree, validating transaction execution by filtering the consensus 
+subtree, and validating the consensus algorithm by filtering out the output subtree.
 
 ![Block Stream Merkle Tree](../assets/hip-1056/block-stream-merkle.svg)
-
-Consensus nodes have a `state merkle tree`, which is a merkle tree containing the current state of the consensus node.
-At each block boundary, the state merkle tree is a depth two *subtree* of a `block merkle tree`. 
-The block merkle tree is a binary merkle tree whose four subtrees at depth two also include the block's input items,
-the block's output items, and the merkle tree of the previous block. 
-Of course Hash computation for the block `N` merkle tree reuses the hash computed for the block `N-1` merkle tree.
 
 > Merkle Item Order vs Block Item Order: Items are split into multiple subtrees, and strict in-order traversal of the
 combined tree will not match the stream order. That is, the order in which items appear in the block merkle tree are
@@ -205,6 +205,35 @@ not the same order in which they are streamed. The left-to-right order of merkle
 which those items are encountered in the stream. Some items are in the "input" subtree and some are in the "output"
 subtree, within those trees the order will be the same as stream-order.
 
+For each block, the `block merkle tree` is specified at a depth of two by the following 4 subtrees: 
+1. The first and left most subtree is the previous block's root hash. 
+2. The second subtree is the input items of the block.
+3. The third subtree is the output items of the block.
+4. The fourth and right most subtree is the root hash of the state at the beginning of the block. 
+
+There are no constraints on the structure of the first and fourth subtrees corresponding to the previous block and the 
+state merkle trees.  The input and output subtrees, however, are balanced binary trees of the same depth to 
+facilitate the following mathematical properties of the merkle paths in these subtrees: 
+1. Let the path from the root of the block merkle tree to a leaf in the input or output subtree be described by an 
+   integer in binary form where a 0 indicates a left turn and a 1 indicates a right turn. 
+2. The path to the input subtree from the root is 01 and the paths to the subtree for consensus block items and 
+   transaction input items are 010 and 011 respectively. 
+3. The path to the output subtree from the root is 10, the paths to the subtree for transaction results and 
+   state changes is 100, and the path to the smart contract execution trace items is 101.
+4. Let the block items in each of the consensus, transaction input, transaction output, and smart contract debug 
+   subtrees be indexed in the order of their appearance starting from 0. 
+5. When the input and output block items have been completely enumerated, each subtree is padded with virtual null 
+   leaves until each subtree becomes a full balanced binary tree of height H where H is the largest height between the 
+   four subtrees.  
+6. Let [b1,b2,b3, ... ,bH] be the binary representation of the index of the block item in the subtree.  If the 
+   prefix to that subtree is [a1,a2,a3] then the path to that block item in the block merkle tree is
+   [a1,a2,a3,b1,b2,b3, ... ,bH]. For example, the merkle path to the first and second consensus block items are [0,1,0,
+   0,0,0, ... 0,0] and [0,1,0,0,0,0, ... 0,1].  The merkle path to first and second transaction output block items are
+   [1,0,0,0,0,0, ... 0,0] and [1,0,0,0,0,0, ... 0,1].  
+
+When whole subtrees are filtered, the block items in the subtree are replaced with a single filtered item indicating 
+the hash of the subtree and the binary merkle path to the subtree from the block merkle root. When individual leaves 
+are filtered, they are replaced with a filtered leaf item that indicates which of the four subtrees the leaf was in. 
 
 > State Merkle Hash: A block contains the state hash that represents the state at the beginning of the block. 
 The hash of the state at the end of the block is found in the next block. This is because it takes time to gather state
@@ -212,6 +241,8 @@ changes of the block and hash them, and waiting for this process would result in
 Rapid block times is a goal of the block stream and thus a tradeoff is made to ensure minimum latency. 
 The impact of this choice is that a state proof for verification of block `N` requires block `N+1`.
 However, the state proof can still be calculated by all the data contained in block `N`. A block is self contained!
+
+
 
 #### Design for Verifiability
 

--- a/HIP/hip-1056.md
+++ b/HIP/hip-1056.md
@@ -242,8 +242,6 @@ Rapid block times is a goal of the block stream and thus a tradeoff is made to e
 The impact of this choice is that a state proof for verification of block `N` requires block `N+1`.
 However, the state proof can still be calculated by all the data contained in block `N`. A block is self contained!
 
-
-
 #### Design for Verifiability
 
 Existing record files contain the following cryptographic properties.


### PR DESCRIPTION
This PR modifies the structure of the input and output merkle trees without modifying the definition of the block proof block item or invalidating the diagrams that are used to depict the merkle tree structure.  