### PR TITLE
filtered items update

### DIFF
--- a/HIP/hip-1056.md
+++ b/HIP/hip-1056.md
@@ -440,7 +440,7 @@ message BlockItem {
         com.hedera.hapi.block.stream.output.StateChanges state_changes = 7;
 
         /**
-         * Verification data for an item filtered from the stream.<br/>
+         * Verification data for items filtered from the stream.<br/>
          * This is a hash for a merkle tree node where the contents of that
          * part of the merkle tree have been removed from this stream.
          */
@@ -1421,28 +1421,29 @@ will not impact the ability for downstream services to validate block proofs.
 ```protobuf
 message FilteredItemHash {
     /**
-    * A hash of an item filtered from the stream.
-    *
-    * The hash algorithm used MUST match the hash algorithm specified in
-    * the block header for the containing block.
+     * A hash of items filtered from the stream.
     */
-    bytes item_hash = 1;
+    bytes hash = 1;
     
     /**
-    * A binary tree path to the tree node that is missing and replaced by the hash above.
+    * A binary tree path to a merkle subtree.
     */
-    uint64 filtered_path = 3;
+    uint64 filtered_path = 2;
+
+    /**
+     * The log2 value of the number of filtered items.<br/>
+     */
+    uint64 log2_item_count = 3;
 }
 ```
 
-> 💡 *Sidebar: Subsetting and Errata for Block Stream.*
-Block stream supports subsetting the block stream through the use of a `FilteredItemHash` to
-replace any item that has been removed. The removed item is thus replaced by its hash and the path that was filtered
-(some removals may require simultaneous removal of a small subtree), which preserves the ability to verify the
-integrity of the block stream and block proof.  Errata are handled similarly for removed items. Adding items *after the
-fact* or replacing an erroneous item requires potentially removing a prior item, and adding the correction (errata) as a
-new item in the block stream at the point of the “errata” transaction, which is then part of the block proof for the
-block where the “errata” was processed.
+> 💡 *Sidebar: Filtering and Errata for Block Stream.* Block stream supports filtering the block stream through the 
+ use of a `FilteredItemHash` to replace any item or subtree that has been removed. The removed subtree is replaced 
+ by its hash and the path that was filtered which preserves the ability to verify the integrity of the block stream 
+ and block proof.  Errata are handled  similarly for removed items. Adding items *after the fact* or replacing an 
+ erroneous item requires potentially removing a prior item, and adding the correction (errata) as a new item in 
+ the block stream at the point of the  “errata” transaction, which is then part of the block proof for the block 
+ where the “errata” was processed.
 
 #### Block Proof
 

--- a/assets/hip-1056/protobuf/stream/block_item.proto
+++ b/assets/hip-1056/protobuf/stream/block_item.proto
@@ -237,7 +237,9 @@ message FilteredItemHash {
     /**
      * A binary tree path to a merkle subtree.
      * This path begins at the root of the block proof merkle tree and ends
-     * at the merkle subtree whose leaf nodes have all been filtered.
+     * at the merkle subtree whose leaf nodes have all been filtered.<br/>
+     * To walk a path `01001` from the root, go left, right, left, left,
+     * then right.
      * <p>
      * This REQUIRED field SHALL describe the full path in the virtual
      * merkle tree constructed for the block proof that contained the

--- a/assets/hip-1056/protobuf/stream/block_item.proto
+++ b/assets/hip-1056/protobuf/stream/block_item.proto
@@ -164,7 +164,7 @@ message BlockItem {
         com.hedera.hapi.block.stream.output.StateChanges state_changes = 7;
 
         /**
-         * Verification data for an item filtered from the stream.<br/>
+         * Verification data for items filtered from the stream.<br/>
          * This is a hash for a merkle tree node where the contents of that
          * part of the merkle tree have been removed from this stream.
          * <p>
@@ -172,9 +172,9 @@ message BlockItem {
          * block stream.<br/>
          * Items of this type SHALL replace any item removed from a partial
          * (filtered) block stream.<br/>
-         * Presence of `filtered_item` entries SHALL NOT prevent verification
-         * of a block, but MAY preclude verification or reconstruction of
-         * consensus state.<br/>
+         * Presence of `filtered_item_hash` entries SHALL NOT prevent
+         * verification of a block, but MAY preclude verification or
+         * reconstruction of consensus state.<br/>
          */
         FilteredItemHash filtered_item_hash = 8;
 
@@ -214,34 +214,47 @@ message BlockItem {
 }
 
 /**
- * Verification data for an item filtered from the stream.
+ * Verification data for items filtered from the stream.
  *
  * Items of this type SHALL NOT be present in the full (unfiltered) block
  * stream.<br/>
  * Items of this type SHALL replace any item removed from a partial (filtered)
  * block stream.<br/>
- * Presence of `filtered_item` entries SHALL NOT prevent verification
+ * Presence of `FilteredItemHash` entries SHALL NOT prevent verification
  * of a block, but MAY preclude verification or reconstruction
  * of consensus state.<br/>
  */
 message FilteredItemHash {
     /**
-     * A hash of an item filtered from the stream.
+     * A hash of items filtered from the stream.
      * <p>
      * The hash algorithm used MUST match the hash algorithm specified in
      * the block header for the containing block.<br/>
      * This field is REQUIRED.
      */
-    bytes item_hash = 1;
+    bytes hash = 1;
 
     /**
-     * A record of the merkle path to the item that was filtered
-     * from the stream.<br/>
-     * This path begins at the root of the block proof merkle tree.
+     * A binary tree path to a merkle subtree.
+     * This path begins at the root of the block proof merkle tree and ends
+     * at the merkle subtree whose leaf nodes have all been filtered.
      * <p>
      * This REQUIRED field SHALL describe the full path in the virtual
      * merkle tree constructed for the block proof that contained the
      * item filtered from the stream.
      */
-    uint64 filtered_path = 3;
+    uint64 filtered_path = 2;
+
+    /**
+     * The log2 value of the number of filtered items.<br/>
+     * Since the filtered merkle subtree is a balanced binary tree, the log2
+     * value of the filtered item count is a whole number.
+     * <p>
+     * The value 2^x where x is this field SHALL be the number of items filtered
+     * in the merkle subtree indicated by the `filtered_path`.
+     */
+    uint64 log2_item_count = 3;
 }
+
+
+


### PR DESCRIPTION
This PR adds the count of the items that were skipped in a filtered merkle subtree.  Since the subtree is a full binary tree, the count is represented as a power of 2.   This allows the field to be absent, defaulting to 0, when the filtered count is 1. 