### PR TITLE
updating specification of index

### DIFF
--- a/assets/hip-1056/protobuf/stream/input/event_header.proto
+++ b/assets/hip-1056/protobuf/stream/input/event_header.proto
@@ -84,8 +84,9 @@ message ParentEventReference {
         /**
          * The index of the parent event.
          * <p>
-         * The index SHALL be the position of the parent event within the
-         * containing block starting from.<br/>
+         * An `EventHeader`'s index SHALL be the count of preceding `EventHeader`
+         * and `RoundHeader` block items starting from the beginning of
+         * the block.<br/>
          * The index SHALL be zero-based.
          */
         uint32 index = 2;


### PR DESCRIPTION
Updating the specification of the index of an `EventHeader` within the block as the count of `EventHeader` and `RoundHeader` items preceding the `EventHeader` from the beginning of a block. 